### PR TITLE
Force unverified connection for local challenge proof

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import argparse, subprocess, json, os, urllib2, sys, base64, binascii, time, \
-    hashlib, re, copy, textwrap
+import argparse, subprocess, json, os, urllib2, ssl, sys, base64, binascii, \
+    time, hashlib, re, copy, textwrap
 
 #CA = "https://acme-staging.api.letsencrypt.org"
 CA = "https://acme-v01.api.letsencrypt.org"
@@ -119,7 +119,7 @@ def get_crt(account_key, csr, acme_dir):
         wellknown_url = "http://{}/.well-known/acme-challenge/{}".format(
             domain, challenge['token'])
         try:
-            resp = urllib2.urlopen(wellknown_url)
+            resp = urllib2.urlopen(wellknown_url, context=ssl._create_unverified_context())
             assert resp.read().strip() == keyauthorization
         except (urllib2.HTTPError, urllib2.URLError, AssertionError):
             os.remove(wellknown_path)


### PR DESCRIPTION
When the existing webserver configuration is set up to forward connections to HTTPS but has an untrusted or invalid certificate, the local challence retrieval fails because Python's ssl lib does certificate validation by default. Letsencyrpt (at least the staging boulder) does not check the cert, so acme_tiny should neither.

This pull request simply adds the unverified context to the urllib-call according to the documentation from urllib2. 