### PR TITLE
use raw regex string

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -19,9 +19,9 @@ def get_crt(account_key, csr, acme_dir):
     if proc.returncode != 0:
         raise IOError("OpenSSL Error: {0}".format(err))
     pub_hex, pub_exp = re.search(
-        "modulus:\n\s+00:([a-f0-9\:\s]+?)\npublicExponent: ([0-9]+)",
+        r"modulus:\n\s+00:([a-f0-9\:\s]+?)\npublicExponent: ([0-9]+)",
         out, re.MULTILINE|re.DOTALL).groups()
-    pub_mod = binascii.unhexlify(re.sub("(\s|:)", "", pub_hex))
+    pub_mod = binascii.unhexlify(re.sub(r"(\s|:)", "", pub_hex))
     pub_mod64 = _b64(pub_mod)
     pub_exp = "{0:x}".format(int(pub_exp))
     pub_exp = "0{0}".format(pub_exp) if len(pub_exp) % 2 else pub_exp
@@ -70,10 +70,10 @@ def get_crt(account_key, csr, acme_dir):
     if proc.returncode != 0:
         raise IOError("Error loading {0}: {1}".format(csr, err))
     domains = set([])
-    common_name = re.search("Subject:.*? CN=([^\s,;/]+)", out)
+    common_name = re.search(r"Subject:.*? CN=([^\s,;/]+)", out)
     if common_name is not None:
         domains.add(common_name.group(1))
-    subject_alt_names = re.search("X509v3 Subject Alternative Name: \n +([^\n]+)\n", out, re.MULTILINE|re.DOTALL)
+    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", out, re.MULTILINE|re.DOTALL)
     if subject_alt_names is not None:
         for san in subject_alt_names.group(1).split(", "):
             if san.startswith("DNS:"):


### PR DESCRIPTION
From https://docs.python.org/2/howto/regex.html#the-backslash-plague:
> backslashes are not handled in any special way in a string literal prefixed with 'r', so r"\n" is a two-character string containing '\' and 'n', while "\n" is a one-character string containing a newline.