### PR TITLE
use textwrap.dedent

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -174,21 +174,23 @@ def get_crt(account_key, csr, acme_dir):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="""\
-This script automates the process of getting a signed TLS certificate from
-Let's Encrypt using the ACME protocol. It will need to be run on your server
-and have access to your private account key, so PLEASE READ THROUGH IT! It's
-only ~200 lines, so it won't take long.
+        description=textwrap.dedent(
+            """\
+            This script automates the process of getting a signed TLS certificate from
+            Let's Encrypt using the ACME protocol. It will need to be run on your server
+            and have access to your private account key, so PLEASE READ THROUGH IT! It's
+            only ~200 lines, so it won't take long.
 
-===Example Usage===
-python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /usr/share/nginx/html/.well-known/acme-challenge/ > signed.crt
-===================
+            ===Example Usage===
+            python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /usr/share/nginx/html/.well-known/acme-challenge/ > signed.crt
+            ===================
 
-===Example Crontab Renewal (once per month)===
-0 0 1 * * python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /usr/share/nginx/html/.well-known/acme-challenge/ > /path/to/signed.crt 2>> /var/log/acme_tiny.log
-==============================================
-
-""")
+            ===Example Crontab Renewal (once per month)===
+            0 0 1 * * python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /usr/share/nginx/html/.well-known/acme-challenge/ > /path/to/signed.crt 2>> /var/log/acme_tiny.log
+            ==============================================
+            """
+        )
+    )
     parser.add_argument("--account-key", required=True, help="path to your Let's Encrypt account private key")
     parser.add_argument("--csr", required=True, help="path to your certificate signing request")
     parser.add_argument("--acme-dir", required=True, help="path to the .well-known/acme-challenge/ directory")
@@ -196,4 +198,3 @@ python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /u
     args = parser.parse_args()
     signed_crt = get_crt(args.account_key, args.csr, args.acme_dir)
     sys.stdout.write(signed_crt)
-


### PR DESCRIPTION
textwrap was already imported, so why not use it? :)
From https://docs.python.org/2/library/textwrap.html#textwrap.dedent:
> This can be used to make triple-quoted strings line up with the left edge of the display, while still presenting them in the source code in indented form.