### PR TITLE
cron example: do not write the certificate if there is an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ for example script).
 Example of a `renew_cert.sh`:
 ```sh
 #!/usr/bin/sh
-python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ > /path/to/signed.crt
+CERT=python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ || exit
+echo $CERT > /path/to/signed.crt
 wget -O - https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem > intermediate.pem
 cat /path/to/signed.crt intermediate.pem > /path/to/chained.pem
 service nginx reload


### PR DESCRIPTION
The current example makes it too easy to shoot yourself in the foot, by overwriting the cert when there's an error renewing it (by running it too many time for testing, or messing up the setup of the challenge directory).