### PR TITLE
adding CA parameter to command line utility

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -5,14 +5,11 @@ try:
 except ImportError:
     from urllib2 import urlopen # Python 2
 
-#CA = "https://acme-staging.api.letsencrypt.org"
-CA = "https://acme-v01.api.letsencrypt.org"
-
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.INFO)
 
-def get_crt(account_key, csr, acme_dir, log=LOGGER):
+def get_crt(account_key, csr, acme_dir, log=LOGGER, CA="https://acme-v01.api.letsencrypt.org"):
 
     # helper function base64 encode for jose spec
     def _b64(b):
@@ -189,8 +186,9 @@ if __name__ == "__main__":
     parser.add_argument("--csr", required=True, help="path to your certificate signing request")
     parser.add_argument("--acme-dir", required=True, help="path to the .well-known/acme-challenge/ directory")
     parser.add_argument("--quiet", action="store_const", const=logging.ERROR, help="suppress output except for errors")
+    parser.add_argument("--ca", required=False, default="https://acme-v01.api.letsencrypt.org", help="ACME CA server to handle requests")
 
     args = parser.parse_args()
     LOGGER.setLevel(args.quiet or LOGGER.level)
-    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, LOGGER)
+    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, LOGGER, CA=args.ca)
     sys.stdout.write(signed_crt)


### PR DESCRIPTION
CA is now a parameter to `get_cert` and the command line utility. This allows for swapping out the ACME servers (staging/production) all within one script. 