### PR TITLE
Fix TypeError: 'str' does not support the buffer interface

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -32,9 +32,9 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     header = {
         "alg": "RS256",
         "jwk": {
-            "e": _b64(binascii.unhexlify(pub_exp)),
+            "e": _b64(binascii.unhexlify(pub_exp.encode("utf-8"))),
             "kty": "RSA",
-            "n": _b64(binascii.unhexlify(re.sub(r"(\s|:)", "", pub_hex))),
+            "n": _b64(binascii.unhexlify(re.sub(r"(\s|:)", "", pub_hex).encode("utf-8"))),
         },
     }
     accountkey_json = json.dumps(header['jwk'], sort_keys=True, separators=(',', ':'))


### PR DESCRIPTION
Running on Python 3.2 (and using acme_tiny as a module), I am getting the following error:

```
Traceback (most recent call last):
  [snip]
  File "server-scripts/letsencrypt-tiny", line 67, in acme
    signed_crt = acme_tiny.get_crt(config['acme']['account-key'], csrfile(name), config['acme']['challenge-dir'])
  File "/home/ralf/letsencrypt/acme-tiny/acme_tiny.py", line 35, in get_crt
    "e": _b64(binascii.unhexlify(pub_exp)),
TypeError: 'str' does not support the buffer interface
```

I can fix that error with the attached patch.
I then ran `./acme_tiny.py` as well to make sure it still works as a Python 2 script.