### PR TITLE
Travis: Test Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 dist: trusty
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"


### PR DESCRIPTION
fcb7cd6f66e951eeae76ff2f48d8ad3e40da37ef is a Python 2.6 fix, so I figured @diafygi would like to support Python 2.6 (which I'm all for!), but then we should also test for Python 2.6.

BTW: Why are Travis builds for PRs disabled?
