### PR TITLE
Added custom user-agent support to mitigate CloudFlare blocking

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
 try:
-    from urllib.request import urlopen # Python 3
+    from urllib.request import urlopen, Request # Python 3
 except ImportError:
-    from urllib2 import urlopen # Python 2
+    from urllib2 import urlopen, Request # Python 2
 
 #DEFAULT_CA = "https://acme-staging.api.letsencrypt.org"
 DEFAULT_CA = "https://acme-v01.api.letsencrypt.org"
+REQUEST_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
@@ -114,7 +115,9 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
         # check that the file is in place
         wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
         try:
-            resp = urlopen(wellknown_url)
+            req = Request(wellknown_url, data=None,
+                headers = { 'User-Agent' : REQUEST_UA })
+            resp = urlopen(req)
             resp_data = resp.read().decode('utf8').strip()
             assert resp_data == keyauthorization
         except (IOError, AssertionError):

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -5,8 +5,7 @@ try:
 except ImportError:
     from urllib2 import urlopen, Request # Python 2
 
-#DEFAULT_CA = "https://acme-staging.api.letsencrypt.org"
-DEFAULT_CA = "https://acme-v01.api.letsencrypt.org"
+DEFAULT_CA = "https://acme-v01.api.letsencrypt.org" # https://acme-staging.api.letsencrypt.org
 REQUEST_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
 
 LOGGER = logging.getLogger(__name__)
@@ -115,9 +114,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
         # check that the file is in place
         wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
         try:
-            req = Request(wellknown_url, data=None,
-                headers = { 'User-Agent' : REQUEST_UA })
-            resp = urlopen(req)
+            resp = urlopen(Request(wellknown_url, headers = { 'User-Agent' : REQUEST_UA })
             resp_data = resp.read().decode('utf8').strip()
             assert resp_data == keyauthorization
         except (IOError, AssertionError):


### PR DESCRIPTION
Occasionally, CloudFlare may block the script from accessing and validating the challenge due to the default user-agent string looking suspicious to CloudFlare, resulting in a HTTP 403 Forbidden. (The default user-agent usually looks like "Python-urllib/x.x", where x.x is the Python version.) This is mitigated by allowing the user to set a browser user-agent, which in turn makes the request succeed.