### PR TITLE
pass CSR as string and only read CSR file once

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -69,7 +69,7 @@ def get_crt_from_csr(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     log.info("Parsing CSR...")
     proc = subprocess.Popen(["openssl", "req", "-noout", "-text"],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = proc.communicate(csr)
+    out, err = proc.communicate(csr.encode('utf8'))
     if proc.returncode != 0:
         raise IOError("OpenSSL CSR Parsing Error: {0}".format(err))
     domains = set([])
@@ -156,7 +156,7 @@ def get_crt_from_csr(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     log.info("Signing certificate...")
     proc = subprocess.Popen(["openssl", "req", "-outform", "DER"],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    csr_der, err = proc.communicate(csr)
+    csr_der, err = proc.communicate(csr.encode('utf8'))
     code, result = _send_signed_request(CA + "/acme/new-cert", {
         "resource": "new-cert",
         "csr": _b64(csr_der),


### PR DESCRIPTION
This patch splits reading the CSR from a file away from the main ACME functionality.
This ensures the CSR file is read only once, which also ensures the same CSR is used for both
calls to  openssl and avoids weird errors if the file is changed while acme-tiny is running.
Additionally, this makes integration of acme-tiny into other projects easier and more secure,
as they can pass the CSR directly by string instead of having to create a temporary file.