### PR TITLE
support python setuptools

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -194,5 +194,18 @@ def main(argv):
     signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca)
     sys.stdout.write(signed_crt)
 
+def __check_deps():
+    # check runtime dependencies (openssl command only)
+    stat, out = subprocess.getstatusoutput("openssl version")
+    if stat != 0:
+        sys.stderr.write(out)
+        sys.stderr.write('\n')
+        sys.exit(stat)
+
+def __entry_point():
+    # needed for setuptools support (see setup.py file)
+    __check_deps()
+    main(sys.argv[1:])
+
 if __name__ == "__main__": # pragma: no cover
     main(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- encoding: utf-8 -*-
+
+from setuptools import setup
+from glob import glob
+
+long_description = """
+acme-tiny is a tiny script to issue and renew TLS certs from Let's Encrypt
+
+This is a tiny, auditable script that you can throw on your server to issue and
+renew Let's Encrypt certificates. Since it has to be run on your server and have
+access to your private Let's Encrypt account key, I tried to make it as tiny as
+possible (currently less than 200 lines). The only prerequisites are python and
+openssl.
+"""
+
+setup(
+    name='acme-tiny',
+    version='20151229',
+
+    description="acme-tiny is a tiny script to issue and renew TLS certs from Let's Encrypt",
+    long_description=long_description,
+
+    license='MIT',
+    url='https://github.com/diafygi/acme-tiny',
+
+    author='Daniel Roesler',
+    author_email='diafygi@gmail.com',
+
+    maintainer='Jeremías Casteglione',
+    maintainer_email='debian@jrms.com.ar',
+
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ],
+
+    keywords='development',
+    py_modules=['acme_tiny'],
+
+    entry_points={
+        'console_scripts': [
+            'acme-tiny=acme_tiny:__entry_point',
+        ],
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # -*- encoding: utf-8 -*-
 
 from setuptools import setup
-from glob import glob
 
 long_description = """
 acme-tiny is a tiny script to issue and renew TLS certs from Let's Encrypt


### PR DESCRIPTION
Hi:

I created a basic setup.py file to support setuptools, so you can do things like:

$ python setup.py install

And then an script under /usr/local/bin is installed as acme-tiny, etc...

I used the timestamp of the latest commit on the repo before I forked it. As there's no any tag/release on this repo (yet?).

I had to create two new funcitons on acme_tiny.py module to better integrate with setuptools.

Thanks for your work on this!

Cheers,


Jeremías