### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ configure an nginx server:
 
 ```
 #NOTE: For nginx, you need to append the Let's Encrypt intermediate cert to your cert
-wget -O - https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem > intermediate.pem
+wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > intermediate.pem
 cat signed.crt intermediate.pem > chained.pem
 ```
 
@@ -173,7 +173,7 @@ Example of a `renew_cert.sh`:
 ```sh
 #!/usr/bin/sh
 python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ > /tmp/signed.crt || exit
-wget -O - https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem > intermediate.pem
+wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > intermediate.pem
 cat /tmp/signed.crt intermediate.pem > /path/to/chained.pem
 service nginx reload
 ```


### PR DESCRIPTION
Let's Encrypt have switched to using their intermediate certificate X3 for signing, see https://letsencrypt.org/certificates/