### PR TITLE
Include licensing information in acme_tiny.py itself

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright (c) 2015 Daniel Roesler, under the MIT license. See LICENSE for more details.
 import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
 try:
     from urllib.request import urlopen # Python 3


### PR DESCRIPTION
Many people simply copy the acme_tiny.py script, meaning they
lose the licensing information that is included in a separate file.

This adds one extra comment line to the top of the file stating
who the copyright owner is, and what license it is under.
