### PR TITLE
Readme: Only needs access to private account key

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ to be run on your server and have access to your private Let's Encrypt account
 key, I tried to make it as tiny as possible (currently less than 200 lines).
 The only prerequisites are python and openssl.
 
-**PLEASE READ THE SOURCE CODE! YOU MUST TRUST IT WITH YOUR PRIVATE KEYS!**
+**PLEASE READ THE SOURCE CODE! YOU MUST TRUST IT WITH YOUR PRIVATE ACCOUNT KEY!**
 
-##Donate
+## Donate
 
 If this script is useful to you, please donate to the EFF. I don't work there,
 but they do fantastic work.


### PR DESCRIPTION
Updated Readme to reflect the fact that this script does not need access to the private TLS key.
(also added one space)
