### PR TITLE
Automatic agreement link

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
+import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging, requests
 try:
     from urllib.request import urlopen # Python 3
 except ImportError:
@@ -82,7 +82,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     log.info("Registering account...")
     code, result = _send_signed_request(CA + "/acme/new-reg", {
         "resource": "new-reg",
-        "agreement": "https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf",
+        "agreement": requests.head('https://acme-v01.api.letsencrypt.org/terms', allow_redirects=False).headers['location'],
     })
     if code == 201:
         log.info("Registered!")

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -82,7 +82,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     log.info("Registering account...")
     code, result = _send_signed_request(CA + "/acme/new-reg", {
         "resource": "new-reg",
-        "agreement": requests.head('https://acme-v01.api.letsencrypt.org/terms', allow_redirects=False).headers['location'],
+        "agreement": requests.head(CA + '/terms', allow_redirects=False).headers['location'],
     })
     if code == 201:
         log.info("Registered!")


### PR DESCRIPTION
Based on https://community.letsencrypt.org/t/how-to-get-url-to-subscriber-agreement-before-registering/2566/2

Using Requests: "The Requests package is recommended for a higher-level HTTP client interface." [https://docs.python.org/2/library/urllib.html]
