### PR TITLE
Support for windows style new lines

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -72,7 +72,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     common_name = re.search(r"Subject:.*? CN=([^\s,;/]+)", out.decode('utf8'))
     if common_name is not None:
         domains.add(common_name.group(1))
-    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE|re.DOTALL)
+    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: [\r\n]+ +([^\r\n]+)[\r\n]+", out.decode('utf8'), re.MULTILINE|re.DOTALL)
     if subject_alt_names is not None:
         for san in subject_alt_names.group(1).split(", "):
             if san.startswith("DNS:"):

--- a/tests/server.py
+++ b/tests/server.py
@@ -11,7 +11,7 @@ def app(req, resp):
             body = req['wsgi.input'].read(body_len).decode("utf8")
             body = re.sub(r"[^A-Za-z0-9_\-\.]", "_", body)
             KEY_AUTHORIZATION['uri'] = "/{0}".format(body.split(".", 1)[0])
-            KEY_AUTHORIZATION['body'] = body
+            KEY_AUTHORIZATION['data'] = body
             resp('201 Created', [])
             return ["".encode("utf8")]
         else:


### PR DESCRIPTION
In openssl 1.1.0 for windows the response uses windows style new lines (\r\n). This change adds support for those.
