### PR TITLE
Apache setting with latest lets-encrypt-x3-cross-signed.pem

### DIFF
--- a/apache.md
+++ b/apache.md
@@ -39,7 +39,7 @@ crontab -e
 
 
 
-Apache2 conf settings:
+Apache2 conf settings, if you do not have the rest of config for 443, then just copy 80's rest of config  to 443's is fine:
 
 
 

--- a/apache.md
+++ b/apache.md
@@ -3,7 +3,7 @@
 
 https://github.com/diafygi/acme-tiny/issues/79
 
-####commands used in setting up the ssl, system ubuntu 14.04 + virtualmin + apache2:
+####commands used in setting up the ssl, system: ubuntu 14.04 + virtualmin + apache2:
 
 
 ```

--- a/apache.md
+++ b/apache.md
@@ -1,5 +1,22 @@
 https://github.com/diafygi/acme-tiny/issues/79
 
+commands used in setting up the ssl, system ubuntu 14.04 + virtualmin + apache2:
+
+openssl genrsa 4096 > account.key
+openssl genrsa 4096 > domain.key
+openssl req -new -sha256 -key domain.key -subj "/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:xxxxxx.com,DNS:www.xxxxxx.com")) > domain.csr
+mkdir -p /home/xxxxxxx/public_html/challenges/
+wget -O - https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py > acme_tiny.py
+python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /home/martnyc/public_html/challenges/ > ./signed.crt
+wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > lets-encrypt-x3-cross-signed.pem
+a2enmod headers
+
+
+
+
+
+
+
 
 
 ```

--- a/apache.md
+++ b/apache.md
@@ -1,3 +1,7 @@
+https://github.com/diafygi/acme-tiny/issues/79
+
+
+
 ```
 <VirtualHost *:80>
    ServerName www.yoursite.com

--- a/apache.md
+++ b/apache.md
@@ -82,10 +82,10 @@ service apache2 reload
    ServerAlias yoursite.com
 
    SSLEngine On
-   SSLCertificateFile "/usr/local/etc/apache24/keys/signed.crt"
-   SSLCertificateKeyFile "/usr/local/etc/apache24/keys/domain.key"
+   SSLCertificateFile "/usr/local/etc/apache/keys/signed.crt"
+   SSLCertificateKeyFile "/usr/local/etc/apache/keys/domain.key"
    # CA certificate from https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem
-   SSLCertificateChainFile "/usr/local/etc/apache24/keys/lets-encrypt-x3-cross-signed.pem"
+   SSLCertificateChainFile "/usr/local/etc/apache/keys/lets-encrypt-x3-cross-signed.pem"
 
    # SSL config according to https://bettercrypto.org/static/applied-crypto-hardening.pdf
    SSLProtocol All -SSLv2 -SSLv3

--- a/apache.md
+++ b/apache.md
@@ -22,7 +22,7 @@ renew ssl every month   renew_cert.sh
 ```
 
 #!/usr/bin/sh
-python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /home/martnyc/public_html/challenges/ > ./signed.crt || exit
+python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /home/xxxxxx/public_html/challenges/ > ./signed.crt || exit
 wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > lets-encrypt-x3-cross-signed.pem
 service apache2 reload
 

--- a/apache.md
+++ b/apache.md
@@ -19,7 +19,7 @@ service apache2 restart
 
 ```
 
-####renew ssl every month   renew_cert.sh
+####renew ssl every month: renew_cert.sh
 
 ```
 
@@ -41,7 +41,8 @@ service apache2 reload
 
 
 
-####Apache2 conf settings, if you do not have the rest of config for 443, then just copy 80's rest of config  to 443's is fine:
+####Apache2 conf settings:
+####If you do not have the rest of config for 443, then just copy 80's rest of config  to 443's is fine:
 
 
 

--- a/apache.md
+++ b/apache.md
@@ -1,0 +1,37 @@
+<VirtualHost *:80>
+   ServerName www.yoursite.com
+   ServerAlias yoursite.com
+
+   Alias /.well-known/acme-challenge/ /usr/local/www/apache24/letsencrypt-challenges/
+   <Directory /usr/local/www/apache24/letsencrypt-challenges>
+      AllowOverride None
+      Require all granted
+      Satisfy Any
+   </Directory>
+
+   # rest of your config for this server
+   # DocumentRoot, ErrorLog, CustomLog...
+</VirtualHost>
+
+<VirtualHost _default_:443>
+   ServerName www.yoursite.com
+   ServerAlias yoursite.com
+
+   SSLEngine On
+   SSLCertificateFile "/usr/local/etc/apache24/keys/domain.crt"
+   SSLCertificateKeyFile "/usr/local/etc/apache24/keys/domain.key"
+   # CA certificate from https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem
+   SSLCertificateChainFile "/usr/local/etc/apache24/keys/lets-encrypt-x1-cross-signed.pem"
+
+   # SSL config according to https://bettercrypto.org/static/applied-crypto-hardening.pdf
+   SSLProtocol All -SSLv2 -SSLv3
+   SSLHonorCipherOrder On
+   SSLCompression Off
+   Header always add Strict-Transport-Security "max-age=15768000"
+   SSLCipherSuite 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA'
+   BrowserMatch "MSIE [2-6]" nokeepalive ssl-unclean-shutdown downgrade-1.0 force-response-1.0
+   BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
+
+   # rest of your SSL/TLS config
+   # DocumentRoot, ErrorLog, CustomLog...
+</VirtualHost>

--- a/apache.md
+++ b/apache.md
@@ -1,3 +1,5 @@
+Apache setting, get hints from the following link:
+
 https://github.com/diafygi/acme-tiny/issues/79
 
 commands used in setting up the ssl, system ubuntu 14.04 + virtualmin + apache2:

--- a/apache.md
+++ b/apache.md
@@ -9,7 +9,7 @@ openssl genrsa 4096 > domain.key
 openssl req -new -sha256 -key domain.key -subj "/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:xxxxxx.com,DNS:www.xxxxxx.com")) > domain.csr
 mkdir -p /home/xxxxxxx/public_html/challenges/
 wget -O - https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py > acme_tiny.py
-python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /home/martnyc/public_html/challenges/ > ./signed.crt
+python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /home/xxxxxx/public_html/challenges/ > ./signed.crt
 wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > lets-encrypt-x3-cross-signed.pem
 a2enmod headers
 

--- a/apache.md
+++ b/apache.md
@@ -106,3 +106,4 @@ service apache2 reload
 RewriteRule ^/(.*):80$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
 
 ```
+#####If you have old ssl setting in the 443 part, then delete them first

--- a/apache.md
+++ b/apache.md
@@ -1,8 +1,9 @@
-###Apache setting with latest lets-encrypt-x3-cross-signed.pem, get hints from the following link:
+###Apache setting with latest lets-encrypt-x3-cross-signed.pem, 
+###Got hints from the following link:
 
 https://github.com/diafygi/acme-tiny/issues/79
 
-###commands used in setting up the ssl, system ubuntu 14.04 + virtualmin + apache2:
+####commands used in setting up the ssl, system ubuntu 14.04 + virtualmin + apache2:
 
 
 ```
@@ -17,7 +18,7 @@ a2enmod headers
 
 ```
 
-###renew ssl every month   renew_cert.sh
+####renew ssl every month   renew_cert.sh
 
 ```
 
@@ -28,7 +29,7 @@ service apache2 reload
 
 ```
 
-###crontab -e
+####crontab -e
 
 ```
 0 0 1 * * /usr/local/etc/apache/keys/renew_cert.sh 2>> /var/log/acme_tiny.log
@@ -39,7 +40,7 @@ service apache2 reload
 
 
 
-###Apache2 conf settings, if you do not have the rest of config for 443, then just copy 80's rest of config  to 443's is fine:
+####Apache2 conf settings, if you do not have the rest of config for 443, then just copy 80's rest of config  to 443's is fine:
 
 
 

--- a/apache.md
+++ b/apache.md
@@ -46,8 +46,8 @@ Apache2 conf settings:
    ServerName www.yoursite.com
    ServerAlias yoursite.com
 
-   Alias /.well-known/acme-challenge/ /usr/local/www/apache24/letsencrypt-challenges/
-   <Directory /usr/local/www/apache24/letsencrypt-challenges>
+   Alias /.well-known/acme-challenge/ /home/xxxxxxx/public_html/challenges/
+   <Directory /home/xxxxxxx/public_html/challenges/>
       AllowOverride None
       Require all granted
       Satisfy Any

--- a/apache.md
+++ b/apache.md
@@ -14,7 +14,7 @@ mkdir -p /home/xxxxxxx/public_html/challenges/
 wget -O - https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py > acme_tiny.py
 ```
 
-####before get certificate signed, we need following config into apache2's http setup:
+####before get certificate signed, we need following config into apache2's http(port 80's setup) setup:
 ```
    Alias /.well-known/acme-challenge/ /home/xxxxxxx/public_html/challenges/
    <Directory /home/xxxxxxx/public_html/challenges/>

--- a/apache.md
+++ b/apache.md
@@ -15,6 +15,27 @@ a2enmod headers
 
 ```
 
+renew ssl every month   renew_cert.sh
+
+```
+
+#!/usr/bin/sh
+python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /home/martnyc/public_html/challenges/ > ./signed.crt || exit
+wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > lets-encrypt-x3-cross-signed.pem
+service apache2 reload
+
+```
+
+crontab -e
+
+```
+0 0 1 * * /usr/local/etc/apache/keys/renew_cert.sh 2>> /var/log/acme_tiny.log
+
+
+```
+
+
+
 
 Apache2 conf settings:
 

--- a/apache.md
+++ b/apache.md
@@ -1,4 +1,4 @@
-<code>
+```
 <VirtualHost *:80>
    ServerName www.yoursite.com
    ServerAlias yoursite.com
@@ -36,5 +36,4 @@
    # rest of your SSL/TLS config
    # DocumentRoot, ErrorLog, CustomLog...
 </VirtualHost>
-
-</code>
+```

--- a/apache.md
+++ b/apache.md
@@ -42,7 +42,7 @@ service apache2 reload
 
 
 ####Apache2 conf settings:
-####If you do not have the rest of config for 443, then just copy 80's rest of config  to 443's:
+#####If you do not have the rest of config for 443, then just copy 80's rest of config  to 443's:
 
 
 
@@ -84,4 +84,10 @@ service apache2 reload
    # rest of your SSL/TLS config
    # DocumentRoot, ErrorLog, CustomLog...
 </VirtualHost>
+```
+#####Forward http request to https:
+#####Add following line into the prot 80 section in the conf file
+```
+RewriteRule ^/(.*):80$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
+
 ```

--- a/apache.md
+++ b/apache.md
@@ -42,7 +42,7 @@ service apache2 reload
 
 
 ####Apache2 conf settings:
-####If you do not have the rest of config for 443, then just copy 80's rest of config  to 443's is fine:
+####If you do not have the rest of config for 443, then just copy 80's rest of config  to 443's:
 
 
 

--- a/apache.md
+++ b/apache.md
@@ -1,8 +1,8 @@
-Apache setting with latest lets-encrypt-x3-cross-signed.pem, get hints from the following link:
+###Apache setting with latest lets-encrypt-x3-cross-signed.pem, get hints from the following link:
 
 https://github.com/diafygi/acme-tiny/issues/79
 
-commands used in setting up the ssl, system ubuntu 14.04 + virtualmin + apache2:
+###commands used in setting up the ssl, system ubuntu 14.04 + virtualmin + apache2:
 
 
 ```
@@ -17,7 +17,7 @@ a2enmod headers
 
 ```
 
-renew ssl every month   renew_cert.sh
+###renew ssl every month   renew_cert.sh
 
 ```
 
@@ -28,7 +28,7 @@ service apache2 reload
 
 ```
 
-crontab -e
+###crontab -e
 
 ```
 0 0 1 * * /usr/local/etc/apache/keys/renew_cert.sh 2>> /var/log/acme_tiny.log
@@ -39,7 +39,7 @@ crontab -e
 
 
 
-Apache2 conf settings, if you do not have the rest of config for 443, then just copy 80's rest of config  to 443's is fine:
+###Apache2 conf settings, if you do not have the rest of config for 443, then just copy 80's rest of config  to 443's is fine:
 
 
 

--- a/apache.md
+++ b/apache.md
@@ -1,4 +1,4 @@
-Apache setting, get hints from the following link:
+Apache setting with latest lets-encrypt-x3-cross-signed.pem, get hints from the following link:
 
 https://github.com/diafygi/acme-tiny/issues/79
 

--- a/apache.md
+++ b/apache.md
@@ -23,7 +23,7 @@ https://github.com/diafygi/acme-tiny/issues/79
    ServerAlias yoursite.com
 
    SSLEngine On
-   SSLCertificateFile "/usr/local/etc/apache24/keys/domain.crt"
+   SSLCertificateFile "/usr/local/etc/apache24/keys/signed.crt"
    SSLCertificateKeyFile "/usr/local/etc/apache24/keys/domain.key"
    # CA certificate from https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem
    SSLCertificateChainFile "/usr/local/etc/apache24/keys/lets-encrypt-x1-cross-signed.pem"

--- a/apache.md
+++ b/apache.md
@@ -1,3 +1,4 @@
+<code>
 <VirtualHost *:80>
    ServerName www.yoursite.com
    ServerAlias yoursite.com
@@ -35,3 +36,5 @@
    # rest of your SSL/TLS config
    # DocumentRoot, ErrorLog, CustomLog...
 </VirtualHost>
+
+</code>

--- a/apache.md
+++ b/apache.md
@@ -2,6 +2,8 @@ https://github.com/diafygi/acme-tiny/issues/79
 
 commands used in setting up the ssl, system ubuntu 14.04 + virtualmin + apache2:
 
+
+```
 openssl genrsa 4096 > account.key
 openssl genrsa 4096 > domain.key
 openssl req -new -sha256 -key domain.key -subj "/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:xxxxxx.com,DNS:www.xxxxxx.com")) > domain.csr
@@ -11,11 +13,10 @@ python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /h
 wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > lets-encrypt-x3-cross-signed.pem
 a2enmod headers
 
+```
 
 
-
-
-
+Apache2 conf settings:
 
 
 

--- a/apache.md
+++ b/apache.md
@@ -25,8 +25,8 @@ https://github.com/diafygi/acme-tiny/issues/79
    SSLEngine On
    SSLCertificateFile "/usr/local/etc/apache24/keys/signed.crt"
    SSLCertificateKeyFile "/usr/local/etc/apache24/keys/domain.key"
-   # CA certificate from https://letsencrypt.org/certs/lets-encrypt-x1-cross-signed.pem
-   SSLCertificateChainFile "/usr/local/etc/apache24/keys/lets-encrypt-x1-cross-signed.pem"
+   # CA certificate from https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem
+   SSLCertificateChainFile "/usr/local/etc/apache24/keys/lets-encrypt-x3-cross-signed.pem"
 
    # SSL config according to https://bettercrypto.org/static/applied-crypto-hardening.pdf
    SSLProtocol All -SSLv2 -SSLv3

--- a/apache.md
+++ b/apache.md
@@ -12,6 +12,21 @@ openssl genrsa 4096 > domain.key
 openssl req -new -sha256 -key domain.key -subj "/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:xxxxxx.com,DNS:www.xxxxxx.com")) > domain.csr
 mkdir -p /home/xxxxxxx/public_html/challenges/
 wget -O - https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.py > acme_tiny.py
+```
+
+####before get certificate signed, we need following config into apache2's http setup:
+```
+   Alias /.well-known/acme-challenge/ /home/xxxxxxx/public_html/challenges/
+   <Directory /home/xxxxxxx/public_html/challenges/>
+      AllowOverride None
+      Require all granted
+      Satisfy Any
+   </Directory>
+```
+
+####then we need restart apache2 and get certificate signed:
+```
+service apache2 restart
 python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /home/xxxxxx/public_html/challenges/ > ./signed.crt
 wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > lets-encrypt-x3-cross-signed.pem
 a2enmod headers

--- a/apache.md
+++ b/apache.md
@@ -36,6 +36,12 @@ service apache2 restart
 
 ####renew ssl every month: renew_cert.sh
 
+
+```
+nano renew_cert.sh
+
+```
+
 ```
 
 #!/usr/bin/sh

--- a/apache.md
+++ b/apache.md
@@ -15,6 +15,7 @@ wget -O - https://raw.githubusercontent.com/diafygi/acme-tiny/master/acme_tiny.p
 python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /home/xxxxxx/public_html/challenges/ > ./signed.crt
 wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > lets-encrypt-x3-cross-signed.pem
 a2enmod headers
+service apache2 restart
 
 ```
 


### PR DESCRIPTION
Apache setting with latest lets-encrypt-x3-cross-signed.pem, full details about setting Let's Encrypt on ubuntu 14.04 and apache 2.4.

Tested in 3 VPS: linode, digital ocean and aws t2.micro