### PR TITLE
Except HTTPError instead of IOError when using urlopen to simplify exception management.

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -2,8 +2,9 @@
 import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
 try:
     from urllib.request import urlopen # Python 3
+    from urllib.error import HTTPError
 except ImportError:
-    from urllib2 import urlopen # Python 2
+    from urllib2 import urlopen, HTTPError # Python 2
 
 #DEFAULT_CA = "https://acme-staging.api.letsencrypt.org"
 DEFAULT_CA = "https://acme-v01.api.letsencrypt.org"
@@ -58,8 +59,8 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
         try:
             resp = urlopen(url, data.encode('utf8'))
             return resp.getcode(), resp.read()
-        except IOError as e:
-            return getattr(e, "code", None), getattr(e, "read", e.__str__)()
+        except HTTPError as httperror:
+            return httperror.getcode(), httperror.read()
 
     # find domains
     log.info("Parsing CSR...")


### PR DESCRIPTION
As discussed in the pull request #89 we can better uses exceptions to return HTTP details from the HTTPError. This allow us to be more explicit on what we except and it avoid to use the `getattr` method to retrieve informations.
