### PR TITLE
Continue when authorization for the account was previously obtained via a different authorization type

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -104,7 +104,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
             raise ValueError("Error requesting challenges: {0} {1}".format(code, result))
 
         # make the challenge file
-        challenge = [c for c in json.loads(result.decode('utf8'))['challenges'] if c['type'] == "http-01"][0]
+        challenge = [c for c in json.loads(result.decode('utf8'))['challenges'] if c['type'] == "http-01" or c['status'] == "valid"][0]
         token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge['token'])
         keyauthorization = "{0}.{1}".format(token, thumbprint)
         wellknown_path = os.path.join(acme_dir, token)


### PR DESCRIPTION
Allow signing of certificates when a prior authorization for the account was previously obtained via a different authorization type. See https://community.letsencrypt.org/t/stuck-at-pending-when-using-dns-challenge/19148 for an example.
