### PR TITLE
Add user agent

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -121,7 +121,8 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
         try:
             q = Request(wellknown_url)
             q.add_header('User-Agent', USER_AGENT)
-            resp = urlopen(q).read().decode('utf8').strip()
+            resp = urlopen(q)
+            resp_data = resp.read().decode('utf8').strip()
             assert resp_data == keyauthorization
         except (IOError, AssertionError):
             os.remove(wellknown_path)


### PR DESCRIPTION
Hi,

actually thanks for the script it's quite good, though I noticed one thing that bugged me.
When using the script as it is, it makes HTTP calls using urlib but the user agent would be generic like that Python-urllib/X.Y. First it's not "nice" (IMHO it's better to inform web servers from who you are to avoid bans, in that kind of case) and secondly it bothers Apache sometimes that blocks this (I guess it's in mod_security or some other). Rather than changing Apache's configuration (it was on a production server) I decided to "fix" the problem at the source, because forbidding user agent like Python-urllib/X.Y seems legit too.
Anyway, so in this PR, it's adding a default user agent for each HTTP calls in the script, so an HTTP call to check the challenge would look like that (las part of the log which matters here):

xxx.xxx.xxx.xxx - - [20/Nov/2016:21:45:21 +0100] "GET /.well-known/acme-challenge/xxxxxxxxxxxxxx HTTP/1.1" 200 282 "-" "acme-tiny // https://github.com/diafygi/acme-tiny"

Obviously, the user agent could be change for the master, I simply put something "easy".
I'm no python dev so I might have done some bad practice thingies but I tried to make it python2/3 compatible, I tested it on python 2.7 and 3.4, and it worked well.
Thanks for considering this PR.

P.S: yeah it makes more line in the script :s