### PR TITLE
challenge_helper proposal for issue #161

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ python:
   - "3.4"
   - "3.5"
   - "nightly"
-before_install:
-  - sudo apt-get install fuse
-  - sudo chmod a+r /etc/fuse.conf
 install:
   - pip install -r tests/requirements.txt
 script:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ and read your private account key and CSR.
 
 ```
 #run the script on your server
-python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /var/www/challenges/ > ./signed.crt
+WEBROOT=/var/www/challenges python acme_tiny.py --account-key ./account.key --csr ./domain.csr --challenge-helper=./writecheck.py --challenge-helper-remove=./removecheck.py > ./signed.crt
 ```
 
 ### Step 5: Install the certificate
@@ -173,7 +173,7 @@ for example script).
 Example of a `renew_cert.sh`:
 ```sh
 #!/usr/bin/sh
-python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ > /tmp/signed.crt || exit
+WEBROOT=/var/www/challenges/ python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --challenge-helper=./writecheck.py --challenge-helper-remove=./removecheck.py > /tmp/signed.crt || exit
 wget -O - https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > intermediate.pem
 cat /tmp/signed.crt intermediate.pem > /path/to/chained.pem
 service nginx reload

--- a/removecheck.py
+++ b/removecheck.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+#
+# Helper script for removing acme challenge
+#
+import os, sys
+def main(token):
+    os.unlink(
+        "{0}/.well-known/acme-challenge/{1}".format(
+            os.environ.get('WEBROOT', ''),
+            token
+        )
+    )
+if __name__ == "__main__": # pragma: no cover
+    main(sys.argv[1:])

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,28 +20,10 @@ variable on your local test setup.
   * `ssh ubuntu@travis-ci.gethttpsforfree.com`
   * `export TRAVIS_SESSION="<random_string_here>"`
   * `sudo server.py`
-4. Install the test requirements on your local (FUSE and optionally coveralls).
-  * `sudo apt-get install fuse`
+4. Install the test requirements on your local (optionally coveralls).
   * `virtualenv /tmp/venv`
   * `source /tmp/venv/bin/activate`
   * `pip install -r requirements.txt`
 5. Run the test suit on your local.
   * `cd /path/to/acme-tiny`
   * `coverage run --source ./ --omit ./tests/server.py -m unittest tests`
-
-## Why use FUSE?
-
-Acme-tiny writes the challenge files for certificate issuance. In order to do
-full integration tests, we actually need to serve correct challenge files to
-the Let's Encrypt staging server on a real domain that they can verify. However,
-Travis-CI doesn't have domains associated with their test VMs, so we need to
-send the files to the remote server that does have a real domain.
-
-The test suite uses FUSE to do this. It creates a FUSE folder that simulates
-being a real folder to acme-tiny. When acme-tiny writes the challenge files
-in the mock folder, FUSE POSTs those files to the real server (which is running
-the included server.py), and the server starts serving them. That way, both
-acme-tiny and Let's Encrypt staging can verify and issue the test certificate.
-This technique allows for high test coverage on automated test runners (e.g.
-Travis-CI).
-

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,9 @@ explains how to setup and test acme-tiny yourself.
 1. Make a test subdomain for a server you control. Set it as an environmental
 variable on your local test setup.
   * On your local: `export TRAVIS_DOMAIN=travis-ci.gethttpsforfree.com`
+  * Configure the webserver on `$TRAVIS_DOMAIN` for redirection of
+    `http://$TRAVIS_DOMAIN/.well-known/acme-challenge/` to
+    `http://localhost:8888/`
 2. Generate a shared secret between your local test setup and your server.
   * `openssl rand -base64 32`
   * On your local: `export TRAVIS_SESSION="<random_string_here>"`

--- a/tests/monkey.py
+++ b/tests/monkey.py
@@ -29,7 +29,9 @@ def gen_keys():
     # subject alt-name domain
     san_csr = NamedTemporaryFile()
     san_conf = NamedTemporaryFile()
-    san_conf.write(open("/etc/ssl/openssl.cnf").read().encode("utf8"))
+    for openssl_cnf in ['/etc/pki/tls/openssl.cnf', '/etc/ssl/openssl.cnf']:
+        if os.path.exists(openssl_cnf): break
+    san_conf.write(open(openssl_cnf).read().encode("utf8"))
     san_conf.write("\n[SAN]\nsubjectAltName=DNS:{0}\n".format(DOMAIN).encode("utf8"))
     san_conf.seek(0)
     Popen(["openssl", "req", "-new", "-sha256", "-key", domain_key.name,

--- a/tests/monkey.py
+++ b/tests/monkey.py
@@ -1,7 +1,7 @@
-import os, sys
+#!/usr/bin/python
+import os, sys, os.path
 from tempfile import NamedTemporaryFile
 from subprocess import Popen
-from fuse import FUSE, Operations, LoggingMixIn
 try:
     from urllib.request import urlopen # Python 3
 except ImportError:
@@ -64,27 +64,6 @@ def gen_keys():
         "account_csr": account_csr,
     }
 
-# fake a folder structure to catch the key authorization file
-FS = {}
-class Passthrough(LoggingMixIn, Operations): # pragma: no cover
-    def getattr(self, path, fh=None):
-        f = FS.get(path, None)
-        if f is None:
-            return super(Passthrough, self).getattr(path, fh=fh)
-        return f
-
-    def write(self, path, buf, offset, fh):
-        urlopen("http://{0}/.well-known/acme-challenge/?{1}".format(DOMAIN,
-            os.getenv("TRAVIS_SESSION", "not_set")), buf)
-        return len(buf)
-
-    def create(self, path, mode, fi=None):
-        FS[path] = {"st_mode": 33204}
-        return 0
-
-    def unlink(self, path):
-        del(FS[path])
-        return 0
-
 if __name__ == "__main__": # pragma: no cover
-    FUSE(Passthrough(), sys.argv[1], nothreads=True, foreground=True)
+    urlopen("http://{0}/.well-known/acme-challenge/?{1}".format(DOMAIN,
+        os.getenv("TRAVIS_SESSION", "not_set")), sys.stdin.read())

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,2 @@
 coveralls
-fusepy
 argparse

--- a/writecheck.py
+++ b/writecheck.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# Helper script for writing acme challenge from stdin to a file named by
+# the first agument to this script, then check if it's reachable over http
+#
+import os, sys, subprocess
+try:
+    from urllib.request import urlopen # Python 3
+except ImportError:
+    from urllib2 import urlopen # Python 2
+
+def main(token):
+    keyauthorization = sys.stdin.read()
+    wellknown_path = "{0}/.well-known/acme-challenge/".format(os.getenv('WEBROOT', ''))
+    if not os.path.isdir(wellknown_path):
+        os.makedirs(wellknown_path)
+    with open(wellknown_path + token, 'wb') as f:
+        f.write(keyauthorization)
+    domain = os.getenv('DOMAIN')
+    # check that the file is in place
+    wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
+
+    resp = urlopen(wellknown_url)
+    resp_data = resp.read().decode('utf8').strip()
+    assert resp_data == keyauthorization
+
+if __name__ == "__main__": # pragma: no cover
+    main(sys.argv[1:])


### PR DESCRIPTION
challenge_helper proposal for issue #161
this also drops the fusefs dependency for tests

I've added "removecheck.py" and "writecheck.py" to preserve the "check if the challenge tokens are correctly in place" and default the "well-known" directory. But if you want to keep things simple (and not fool proof...) you can use the defaults for challenge-helper (tee) and challenger-helper-remove (rm) and call acme-tiny from the ".well-known/acme-challenge" directory.