### PR TITLE
Don't fail on openssl 1.1 output

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -69,7 +69,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     if proc.returncode != 0:
         raise IOError("Error loading {0}: {1}".format(csr, err))
     domains = set([])
-    common_name = re.search(r"Subject:.*? CN=([^\s,;/]+)", out.decode('utf8'))
+    common_name = re.search(r"Subject:.*? CN ?= ?([^\s,;/]+)", out.decode('utf8'))
     if common_name is not None:
         domains.add(common_name.group(1))
     subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE|re.DOTALL)


### PR DESCRIPTION
A subject only CN entry looks in openssl 1.0.2 and earlier like:
	Subject: CN=xxx.domain.tld

The output with 1.1.0+ differs slightly:
        Subject: CN = xxx.domain.tld

This is enough to get the script confused and to continue with zero
domains and fail later:

|Parsing account key...
|Parsing CSR...
|Registering account...
|Already registered!
|Signing certificate...
|Traceback (most recent call last):
|  File "/home/letsencrypt/acme-tiny/acme_tiny.py", line 198, in <module>
|    main(sys.argv[1:])
|  File "/home/letsencrypt/acme-tiny/acme_tiny.py", line 194, in main
|    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca)
|  File "/home/letsencrypt/acme-tiny/acme_tiny.py", line 161, in get_crt
|    raise ValueError("Error signing certificate: {0} {1}".format(code, result))
|ValueError: Error signing certificate: 403 {
|  "type": "urn:acme:error:unauthorized",
|  "detail": "Error creating new cert :: Authorizations for these names not found or expired: xxx.domain.tld",
|  "status": 403
|}

With this change it should work again. Maybe the script could stop after
parsing the CSR if zero domains were found.

Signed-off-by: Sebastian Andrzej Siewior <bigeasy@linutronix.de>