### PR TITLE
FIX CN parsing to work with OpenSSL 1.1

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -69,7 +69,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     if proc.returncode != 0:
         raise IOError("Error loading {0}: {1}".format(csr, err))
     domains = set([])
-    common_name = re.search(r"Subject:.*? CN=([^\s,;/]+)", out.decode('utf8'))
+    common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", out.decode('utf8'))
     if common_name is not None:
         domains.add(common_name.group(1))
     subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE|re.DOTALL)


### PR DESCRIPTION
CN used to be without whitespaces around the `=` but OpenSSL 1.1 introduced
whitespaces:
1.0.1: subject=/CN=example.com
1.1.0: subject=CN = example.com

This commit makes them optional.