### PR TITLE
Use a better wellknown URL

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -112,7 +112,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
             wellknown_file.write(keyauthorization)
 
         # check that the file is in place
-        wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
+        wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format("127.0.0.1", token)
         try:
             resp = urlopen(wellknown_url)
             resp_data = resp.read().decode('utf8').strip()


### PR DESCRIPTION
Use a URL that is more likely to work for testing the http challenge locally.

This keeps tripping up people...
solves #178, relates to #185