### PR TITLE
Added --skip-well-known-check option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Embedded git
+.egit

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ and read your private account key and CSR.
 python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /var/www/challenges/ > ./signed.crt
 ```
 
+Note: if you are running behind a firewall in a local address space there is a good chance that the local http check of 
+the `.well-known/acme-challenge/` URI might not work.  In this case, use the `--skip-well-known-check` option.  
+It is up to you to verify that the lets encrypt server can reach your `.well-known/acme-challenge/` URI.
+
 ### Step 5: Install the certificate
 
 The signed https certificate that is output by this script can be used along

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -195,10 +195,12 @@ def main(argv):
     parser.add_argument("--acme-dir", required=True, help="path to the .well-known/acme-challenge/ directory")
     parser.add_argument("--quiet", action="store_const", const=logging.ERROR, help="suppress output except for errors")
     parser.add_argument("--ca", default=DEFAULT_CA, help="certificate authority, default is Let's Encrypt")
+    parser.add_argument("--skip-well-known-check", action="store_true", help="Skip the local http check of .well-knonw/acme-challenge/")
 
     args = parser.parse_args(argv)
     LOGGER.setLevel(args.quiet or LOGGER.level)
-    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca)
+    WellKnownCheck = not args.skip_well_known_check
+    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, WellKnownCheck=WellKnownCheck)
     sys.stdout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# vim:fileencoding=utf-8:ts=4:sw=4:expandtab
 import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
 try:
     from urllib.request import urlopen # Python 3
@@ -12,7 +13,11 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.INFO)
 
-def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
+def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, WellKnownCheck=True):
+    '''
+    Sometimes the local well known check can't be done due to firewall or lan/wan routing issues.
+
+    '''
     # helper function base64 encode for jose spec
     def _b64(b):
         return base64.urlsafe_b64encode(b).decode('utf8').replace("=", "")
@@ -113,14 +118,16 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
 
         # check that the file is in place
         wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
-        try:
-            resp = urlopen(wellknown_url)
-            resp_data = resp.read().decode('utf8').strip()
-            assert resp_data == keyauthorization
-        except (IOError, AssertionError):
-            os.remove(wellknown_path)
-            raise ValueError("Wrote file to {0}, but couldn't download {1}".format(
-                wellknown_path, wellknown_url))
+
+        if WellKnownCheck:
+            try:
+                resp = urlopen(wellknown_url)
+                resp_data = resp.read().decode('utf8').strip()
+                assert resp_data == keyauthorization
+            except (IOError, AssertionError):
+                os.remove(wellknown_path)
+                raise ValueError("Wrote file to {0}, but couldn't download {1}".format(
+                    wellknown_path, wellknown_url))
 
         # notify challenge are met
         code, result = _send_signed_request(challenge['uri'], {


### PR DESCRIPTION
While we were working with this awesome little library we found that the local http check of the challenge was not working because our server was behind a VPC (very common config for larger installations).

The server was running on 192.168.1.0/24 address space, while the public IP was 50.12.X.X.  The local check to our `http://www.example.com/.well-known/acme-challenge/...` file was failing due to not being able to resolve the 50.12.X.X IP address from 192.168.1.0/24.

The `--skip-well-known-check` command line option as well as the default `WellKnownCheck=True` function argument, and requisite documentation have all been added.