### PR TITLE
check that the file is in place: allow unverified ssl

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
+import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging, ssl
 try:
     from urllib.request import urlopen # Python 3
 except ImportError:
@@ -114,7 +114,10 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
         # check that the file is in place
         wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
         try:
-            resp = urlopen(wellknown_url)
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            resp = urlopen(wellknown_url, context=ctx)
             resp_data = resp.read().decode('utf8').strip()
             assert resp_data == keyauthorization
         except (IOError, AssertionError):


### PR DESCRIPTION
Hi,

This patch is for allowing insecure https in the "[check that the file is in place](https://github.com/diafygi/acme-tiny/blob/19b274cf38544ad9ccc69aa140969c30c4e0d8fd/acme_tiny.py#L114)" procedure.
This is for example useful in the case where you have a working setup with a http -> https redirection and you want to add a new subdomain xxx.example.com. Since your current certificate doesn't include the new subdomain xxx.example.com then [the urlopen](https://github.com/diafygi/acme-tiny/blob/19b274cf38544ad9ccc69aa140969c30c4e0d8fd/acme_tiny.py#L117) fails.
The thing is that let's encrypt doesn't care if the certificate is correct, which is somewhat logical because you are not supposed to have a valid ssl certificate before getting one from let's encrypt. Also the local urlopen check done by acme-tiny is only there for good measure not to disturb let's encrypt if the web-server configuration isn't even correct.

Similar to #157 but with explanation

Cheers,
Pierre