### PR TITLE
make ca url adjustable via env variable

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -5,8 +5,7 @@ try:
 except ImportError:
     from urllib2 import urlopen # Python 2
 
-#DEFAULT_CA = "https://acme-staging.api.letsencrypt.org"
-DEFAULT_CA = "https://acme-v01.api.letsencrypt.org"
+DEFAULT_CA = os.environ["ACME_URL"] if "ACME_URL" in os.environ else "https://acme-v01.api.letsencrypt.org"
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())


### PR DESCRIPTION
I'd like to make the CA API URL adjustable via an environment variable. This makes it easier to cretae test scenarios by only providing the environment variable for the testing endpoint:

    ACME_URL="https://acme-staging.api.letsencrypt.org" ./acme_tiny.py …