### PR TITLE
Make ACME URL adjustable via an environment variable

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -7,8 +7,7 @@ except ImportError:
     from urllib2 import urlopen, Request # Python 2
 
 DEFAULT_CA = "https://acme-v02.api.letsencrypt.org" # DEPRECATED! USE DEFAULT_DIRECTORY_URL INSTEAD
-LE_ACME_V2_URL="https://acme-v02.api.letsencrypt.org/directory"
-DEFAULT_DIRECTORY_URL = os.environ["ACME_V2_URL"] if "ACME_V2_URL" in os.environ else LE_ACME_V2_URL
+DEFAULT_DIRECTORY_URL = os.environ.get("ACME_V2_URL", "https://acme-v02.api.letsencrypt.org/directory")
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -7,7 +7,8 @@ except ImportError:
     from urllib2 import urlopen, Request # Python 2
 
 DEFAULT_CA = "https://acme-v02.api.letsencrypt.org" # DEPRECATED! USE DEFAULT_DIRECTORY_URL INSTEAD
-DEFAULT_DIRECTORY_URL = "https://acme-v02.api.letsencrypt.org/directory"
+LE_ACME_V2_URL="https://acme-v02.api.letsencrypt.org/directory"
+DEFAULT_DIRECTORY_URL = os.environ["ACME_V2_URL"] if "ACME_V2_URL" in os.environ else LE_ACME_V2_URL
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())


### PR DESCRIPTION
I'd like to make the ACME V2 API URL adjustable via an environment variable. This makes it easier to create test scenarios by only providing the environment variable for the testing endpoint.

    ACME_V2_URL="https://acme-staging-v02.api.letsencrypt.org/directory" ./acme_tiny.py …

Regarding #193:

> you can use the command line options

Often the actual invocation is part of a shell script which shall remain the same. The env variable allows to switch to the staging URL from outside the script.

> call `get_crt()` directly with the `directory_url`

This would break the principle of information hiding and also wouldn't satisfy the former point.