### PR TITLE
Avoid deleting certificate when renewal fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ for example script).
 Example of a `renew_cert.sh`:
 ```sh
 #!/usr/bin/sh
-python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ > /path/to/signed_chain.crt || exit
+cert=$(python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/) && echo $cert > /path/to/signed_chain.crt || exit
 service nginx reload
 ```
 


### PR DESCRIPTION
The current example renewal script in the README documentation truncates /path/to/signed_chain.crt when the renewal script raises an exception. This should make it a bit more robust.