### PR TITLE
Proposed 4.1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "nightly"
 before_install:
   - sudo apt-get install fuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,20 @@ sudo: required
 language: python
 matrix:
   include:
-  - name: "ubuntu 14.04"
-    dist: trusty
-    python:
-      - "3.3"
-  - name: "ubuntu 16.04"
-    dist: xenial
-    python:
-      - "2.7"
-      - "3.4"
-      - "3.5"
-      - "3.6"
-      - "3.7"
-      - "nightly"
+    - dist: xenial
+      python: "2.7"
+    - dist: trusty
+      python: "3.3"
+    - dist: xenial
+      python: "3.4"
+    - dist: xenial
+      python: "3.5"
+    - dist: xenial
+      python: "3.6"
+    - dist: xenial
+      python: "3.7"
+    - dist: xenial
+      python: "nightly"
 before_install:
   - sudo apt-get install fuse
   - sudo chmod a+r /etc/fuse.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 sudo: required
-dist: xenial
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "nightly"
+matrix:
+  include:
+  - name: "ubuntu 14.04"
+    dist: trusty
+    python:
+      - "3.3"
+  - name: "ubuntu 16.04"
+    dist: xenial
+    python:
+      - "2.7"
+      - "3.4"
+      - "3.5"
+      - "3.6"
+      - "3.7"
+      - "nightly"
 before_install:
   - sudo apt-get install fuse
   - sudo chmod a+r /etc/fuse.conf

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ for example script).
 Example of a `renew_cert.sh`:
 ```sh
 #!/usr/bin/sh
-python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ > /path/to/signed_chain.crt || exit
+cert=$(python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/) && echo $cert > /path/to/signed_chain.crt || exit
 service nginx reload
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ for example script).
 Example of a `renew_cert.sh`:
 ```sh
 #!/usr/bin/sh
-cert=$(python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/) && echo $cert > /path/to/signed_chain.crt || exit
+python /path/to/acme_tiny.py --account-key /path/to/account.key --csr /path/to/domain.csr --acme-dir /var/www/challenges/ > /path/to/signed_chain.crt.tmp || exit
+mv /path/to/signed_chain.crt.tmp /path/to/signed_chain.crt
 service nginx reload
 ```
 

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -67,7 +67,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
         while result is None or result['status'] in pending_statuses:
             assert (time.time() - t0 < 3600), "Polling timeout" # 1 hour timeout
             time.sleep(0 if result is None else 2)
-            result, _, _ = _do_request(url, err_msg=err_msg)
+            result, _, _ = _send_signed_request(url, None, err_msg)
         return result
 
     # parse account key to get public key

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -140,7 +140,6 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
             wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
             assert (disable_check or _do_request(wellknown_url)[0] == keyauthorization)
         except (AssertionError, ValueError) as e:
-            os.remove(wellknown_path)
             raise ValueError("Wrote file to {0}, but couldn't download {1}: {2}".format(wellknown_path, wellknown_url, e))
 
         # say the challenge is done
@@ -148,6 +147,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
         authorization = _poll_until_not(auth_url, ["pending"], "Error checking challenge status for {0}".format(domain))
         if authorization['status'] != "valid":
             raise ValueError("Challenge did not pass for {0}: {1}".format(domain, authorization))
+        os.remove(wellknown_path)
         log.info("{0} verified!".format(domain))
 
     # finalize the order with the csr

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -93,7 +93,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
     common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", out.decode('utf8'))
     if common_name is not None:
         domains.add(common_name.group(1))
-    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE|re.DOTALL)
+    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: (?:critical)?\n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE|re.DOTALL)
     if subject_alt_names is not None:
         for san in subject_alt_names.group(1).split(", "):
             if san.startswith("DNS:"):

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -63,12 +63,12 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
 
     # helper function - poll until complete
     def _poll_until_not(url, pending_statuses, err_msg):
-        while True:
-            result, _, _ = _send_signed_request(url, None, err_msg)
-            if result['status'] in pending_statuses:
-                time.sleep(2)
-                continue
-            return result
+        result, t0 = None, time.time()
+        while result is None or result['status'] in pending_statuses:
+            assert (time.time() - t0 < 3600), "Polling timeout" # 1 hour timeout
+            time.sleep(0 if result is None else 2)
+            result, _, _ = _do_request(url, err_msg=err_msg)
+        return result
 
     # parse account key to get public key
     log.info("Parsing account key...")

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -48,7 +48,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
 
     # helper function - make signed requests
     def _send_signed_request(url, payload, err_msg, depth=0):
-        payload64 = _b64(json.dumps(payload).encode('utf8'))
+        payload64 = "" if payload is None else _b64(json.dumps(payload).encode('utf8'))
         new_nonce = _do_request(directory['newNonce'])[2]['Replay-Nonce']
         protected = {"url": url, "alg": alg, "nonce": new_nonce}
         protected.update({"jwk": jwk} if acct_headers is None else {"kid": acct_headers['Location']})
@@ -64,7 +64,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
     # helper function - poll until complete
     def _poll_until_not(url, pending_statuses, err_msg):
         while True:
-            result, _, _ = _do_request(url, err_msg=err_msg)
+            result, _, _ = _send_signed_request(url, None, err_msg)
             if result['status'] in pending_statuses:
                 time.sleep(2)
                 continue
@@ -123,7 +123,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
 
     # get the authorizations that need to be completed
     for auth_url in order['authorizations']:
-        authorization, _, _ = _do_request(auth_url, err_msg="Error getting challenges")
+        authorization, _, _ = _send_signed_request(auth_url, None, "Error getting challenges")
         domain = authorization['identifier']['value']
         log.info("Verifying {0}...".format(domain))
 
@@ -161,7 +161,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
         raise ValueError("Order failed: {0}".format(order))
 
     # download the certificate
-    certificate_pem, _, _ = _do_request(order['certificate'], err_msg="Certificate download failed")
+    certificate_pem, _, _ = _send_signed_request(order['certificate'], None, "Certificate download failed")
     log.info("Certificate signed!")
     return certificate_pem
 

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -138,7 +138,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
         # check that the file is in place
         try:
             wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
-            assert(disable_check or _do_request(wellknown_url)[0] == keyauthorization)
+            assert (disable_check or _do_request(wellknown_url)[0] == keyauthorization)
         except (AssertionError, ValueError) as e:
             os.remove(wellknown_path)
             raise ValueError("Wrote file to {0}, but couldn't download {1}: {2}".format(wellknown_path, wellknown_url, e))

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -165,7 +165,7 @@ class TestModule(unittest.TestCase):
             "--csr", KEYS['domain_csr'].name,
             "--acme-dir", self.tempdir,
             "--directory-url", self.DIR_URL,
-            "--contact", "mailto:devteam@example.com", "mailto:boss@example.com",
+            "--contact", "mailto:devteam@gethttpsforfree.com", "mailto:boss@gethttpsforfree.com",
         ])
         sys.stdout.seek(0)
         crt = sys.stdout.read().encode("utf8")
@@ -175,7 +175,7 @@ class TestModule(unittest.TestCase):
         # make sure the certificate was issued and the contact details were updated
         out, err = Popen(["openssl", "x509", "-text", "-noout"], stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate(crt)
         self.assertIn("Issuer: CN=Fake LE Intermediate", out.decode("utf8"))
-        self.assertIn("Updated contact details:\nmailto:devteam@example.com\nmailto:boss@example.com", log_string.decode("utf8"))
+        self.assertIn("Updated contact details:\nmailto:devteam@gethttpsforfree.com\nmailto:boss@gethttpsforfree.com", log_string.decode("utf8"))
         # remove logging capture
         acme_tiny.LOGGER.removeHandler(debug_handler)
 


### PR DESCRIPTION
CHANGELOG
* Support POST-as-GET from updated ACME spec (RFC 8555) - Let's Encrypt will drop support for plain GET requests in November 2019 (issue #226)
* Added explicit Python 3.7 support and fixed continuous integration tests
* Added timeout to request polling to prevent infinitely waiting (pull #205)
* Added support for critical SAN extensions (issue #216, pull #217)
* Started cleaning up challenge files on success (pointed out by @felixfontein in issue #222)

I feel like supporting POST-as-GET, which is a breaking change from Let's Encrypt, warrants a minor version bump.