### PR TITLE
Recommend -addext for subjectAltName

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ openssl genrsa 4096 > domain.key
 openssl req -new -sha256 -key domain.key -subj "/CN=yoursite.com" > domain.csr
 
 # For multiple domains (use this one if you want both www.yoursite.com and yoursite.com)
+openssl req -new -sha256 -key domain.key -subj "/" -addext "subjectAltName = DNS:yoursite.com, DNS:www.yoursite.com" > domain.csr
+
+# For multiple domains, if running on Debian 9, Ubuntu 18.04 w/o updates, or any older operating system not shipping OpenSSL v1.1.1+
 openssl req -new -sha256 -key domain.key -subj "/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:yoursite.com,DNS:www.yoursite.com")) > domain.csr
 ```
 


### PR DESCRIPTION
We [no longer](https://github.com/openssl/openssl/commit/bfa470a4f64313651a35571883e235d3335054eb) have to use such a messy/kludgy/breakable syntax to add `subjectAltName` entries to a CSR.

This pull request updates the README to recommend the new, officially-supported syntax, while still listing the old workaround for versions of OpenSSL that don't officially support adding `subjectAltName`s inline.