### PR TITLE
Set interpreter to 'python3'

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright Daniel Roesler, under MIT license, see LICENSE at github.com/diafygi/acme-tiny
 import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
 try:


### PR DESCRIPTION
People over at the DebOps project encountered problems running
acme-tiny on Python 3-only systems [1]. As described in the Debian
Python Policy [2], this behaviour is expected when using the
(discouraged) 'python' interpreter. This commit modifies the shebang
line to specify the 'python3' interpreter instead.

[1] https://github.com/debops/debops/issues/1079#issuecomment-562854976
[2] https://www.debian.org/doc/packaging-manuals/python-policy/python.html#interpreter