### PR TITLE
Add --dry-run command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ reload your webserver without having permission to do anything else.
 * Don't allow this script to be able to read your domain private key!
 * Don't allow this script to be run as root!
 
+## Staging Environment
+
+Let's Encrypt recommends testing new configurations against their staging directory.
+Use `--dry-run` to set directory url appropriatly. For more information see
+[https://letsencrypt.org/docs/staging-environment/](https://letsencrypt.org/docs/staging-environment/).
+
 ## Feedback/Contributing
 
 This project has a very, very limited scope and codebase. I'm happy to receive

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -8,6 +8,7 @@ except ImportError:
 
 DEFAULT_CA = "https://acme-v02.api.letsencrypt.org" # DEPRECATED! USE DEFAULT_DIRECTORY_URL INSTEAD
 DEFAULT_DIRECTORY_URL = "https://acme-v02.api.letsencrypt.org/directory"
+DEFAULT_STAGING_DIRECTORY_URL = "https://acme-staging-v02.api.letsencrypt.org/directory"
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
@@ -186,6 +187,7 @@ def main(argv=None):
     parser.add_argument("--quiet", action="store_const", const=logging.ERROR, help="suppress output except for errors")
     parser.add_argument("--disable-check", default=False, action="store_true", help="disable checking if the challenge file is hosted correctly before telling the CA")
     parser.add_argument("--directory-url", default=DEFAULT_DIRECTORY_URL, help="certificate authority directory url, default is Let's Encrypt")
+    parser.add_argument("--dry-run", action="store_const", const=DEFAULT_STAGING_DIRECTORY_URL, dest="directory_url", help="use Let's Encrypt staging directory")
     parser.add_argument("--ca", default=DEFAULT_CA, help="DEPRECATED! USE --directory-url INSTEAD!")
     parser.add_argument("--contact", metavar="CONTACT", default=None, nargs="*", help="Contact details (e.g. mailto:aaa@bbb.com) for your account-key")
 


### PR DESCRIPTION
The --dry-run option is a shortcut for

  --directory-url https://acme-staging-v02.api.letsencrypt.org/directory

to use Let's Encrypt staging environment for testing.