### PR TITLE
Improve processing.

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright Daniel Roesler, under MIT license, see LICENSE at github.com/diafygi/acme-tiny
-import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging, time
+import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
 try:
     from urllib.request import urlopen, Request # Python 3
 except ImportError:
@@ -44,7 +44,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
             resp_data = json.loads(resp_data) # try to parse json results
         except ValueError:
             pass # ignore json parsing errors
-        if code == 400 and resp_data['type'] and depth < 100 == "urn:ietf:params:acme:error:badNonce":
+        if code == 400 and resp_data['type'] == "urn:ietf:params:acme:error:badNonce" and depth < 100:
             raise IndexError(resp_data) # allow 100 retrys for bad nonces
         if code not in [200, 201, 204]:
             raise ValueError("{0}:\nUrl: {1}\nData: {2}\nResponse Code: {3}\nResponse: {4}".format(err_msg, url, data, code, resp_data))


### PR DESCRIPTION
Improve the process of obtaining nonce to save the number of requests that needed to be sent to the server. Improve the process of handling the authorization requests. Improve the process of polling the challenges. Modify the code for obtaining the URLs from the directory. Added a static header for all outgoing requests.

Although I know there is a 200 code-lines limitation for this project, I thought this pull request will add additional values to the project. This pull request will increase the code lines to 239. This pull request does not offer any new feature, it just improves the current features. This pull request took into consideration the framework of the original code.

For this pull request, I updated:
1) How the nonce is obtained to save the number of requests that needed to be sent to the server.
2) How the authorization requests are processed.
3) How the challenges are polled.
4) How the directory is obtained.
5) Static header.

NONCE: 

Section 6.5 of page 14 of rfc8555(https://tools.ietf.org/html/rfc8555): "An ACME server provides nonces to clients using the HTTP Replay-Nonce header field, as specified in Section 6.5.1.  The server MUST include a Replay-Nonce header field in every successful response to a POST request and SHOULD provide it in error responses as well..."

Thus, the server should provide a valid nonce for the next request whenever it responds to a request, including erroneous requests. Thus, there is no reason to use the newonce API except for the first request that is after obtaining the URLs from the directory. Take note that the URL for obtaining the URLs of the directory does not provide a nonce.

I also did took note that this code was probably written with support to legacy versions of python in mind. Thus, the headers field may not be available when urllib encounters an error. Thus, I updated the code to only obtain a new nonce after obtaining the directory's URLs or when an error is encountered by the _do_request method. Otherwise, the do_request method will save the nonce that is obtained from a successful request from the "Replay-Nonce" header field, and then use that nonce for the next request. 

Since nonces are obtained differently, I wrote a new method, _new_nonce for obtaining a new nonce. For that method, I didn't catch any exception, as newnonce is the most basic URL and if contacting that URL gives any error, there must be something wrong with the configuration and the program should terminate.

I tested the code to obtain a certificate that had 94 domains attached to it, the call to the newnonce URL only happened one.

Authorization Request Processing:

When fulfilling an order, it seemed the acme server doesn't need the authorization requests to be processed one at a time. Also took note of page 64 of RFC-8555 document(https://tools.ietf.org/html/rfc8555), a description for the token was written. In the description: "token (required, string): A random value that uniquely identifies the challenge...". Thus, for the same order, the acme server shouldn't use the same token for more than one authorization request. Thus, if the server follows the RFC-8555 standard, all authorization requests can be processed at once without worrying about file naming conflict(token naming conflict).

With that in mind, for this pull request, I modified how the authorization requests are handled. For the authorization requests, the code will set up all the authorization requests at one, and then it will trigger the acme server to verify the requests without polling any request for their status. After setting up all the authorization requests, the code will then poll each authorization request for their status. 

Challenges Polling:

Since all the authorization requests are setting up before polling and on orders that have a large number of domains, the acme server probably already finished with verifying some, if not most authorization requests. Therefore, I altered _poll_until_not method to be more optimized for the new code. The _poll_until_not method will now contact the server first before making any assertion. For assertion, instead of asserting "current time - started time < 3600", the code will start with "started time + 3600"(timeout time) and then each loop the code will assert if the "current time" is smaller than that "started time"(timeout time).

Contacting The Directory:

Since obtaining the directory is just a simple GET request, I created a new method _get_directory for obtaining the URLs from the directory. Although the RFC-8555 did not mention if the directory can give out any other successful code, I assumed on a successful request to the directory, it should only give out the 200 code. Also, for that method, if the data can't be loaded to JSON, the program should terminate because that probably is a wrong URL.

Static Header:

Since all the outgoing requests from acme-tiny are going to carry the same header, I created a CONST_HEADER global variable that is used by all the methods whenever they make a request.