### PR TITLE
skip valid authorizations

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -127,6 +127,11 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
         domain = authorization['identifier']['value']
         log.info("Verifying {0}...".format(domain))
 
+        # skip if already valid
+        if authorization['status'] == "valid":
+            log.info("{0} already verified. Skipping.".format(domain))
+            continue
+
         # find the http-01 challenge and write the challenge file
         challenge = [c for c in authorization['challenges'] if c['type'] == "http-01"][0]
         token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge['token'])


### PR DESCRIPTION
Authorizations that already have a status of "valid" do not need
to be validated again (until the authorization expires).
Skipping these authorizations makes it possible to obtain certificates
for domains for which a dns-01 validation is still valid, as
acme_tiny is unable to re-validate them. (The alternative would be
to wait up to a month until the authorization expires, or use a
different acme client.)