### PR TITLE
Log the Let’s Encrypt account ID

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -110,7 +110,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
     log.info("Registering account...")
     reg_payload = {"termsOfServiceAgreed": True}
     account, code, acct_headers = _send_signed_request(directory['newAccount'], reg_payload, "Error registering")
-    log.info("Registered!" if code == 201 else "Already registered!")
+    log.info("Registered! Account ID: {0}".format(acct_headers['Location']) if code == 201 else "Already registered! Account ID: {0}".format(acct_headers['Location']))
     if contact is not None:
         account, _, _ = _send_signed_request(acct_headers['Location'], {"contact": contact}, "Error updating contact details")
         log.info("Updated contact details:\n{0}".format("\n".join(account['contact'])))


### PR DESCRIPTION
Just a small change to log (or print) the Let’s Encrypt [account ID](https://letsencrypt.org/docs/account-id/).
It is useful to have this information for certain tasks like [opting in](https://community.letsencrypt.org/t/ecdsa-availability-in-production-environment/150679) for ECDSA intermediates.

Feel free to merge if you consider this useful too.