### PR TITLE
add contact to initial registration request

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -108,7 +108,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
 
     # create account, update contact details (if any), and set the global key identifier
     log.info("Registering account...")
-    reg_payload = {"termsOfServiceAgreed": True}
+    reg_payload = {"termsOfServiceAgreed": True} if contact is None else {"termsOfServiceAgreed": True, "contact": contact}
     account, code, acct_headers = _send_signed_request(directory['newAccount'], reg_payload, "Error registering")
     log.info("{0} Account ID: {1}".format("Registered!" if code == 201 else "Already registered!", acct_headers['Location']))
     if contact is not None:


### PR DESCRIPTION
From #241, some other ACME CAs (besides Let's Encrypt) require contact info to register an initial account.

This pull request adds contact info (if provided) by default to the initial account registration request.