### PR TITLE
add arg --outfile

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -194,7 +194,9 @@ def main(argv=None):
     args = parser.parse_args(argv)
     LOGGER.setLevel(args.quiet or LOGGER.level)
     signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, check_port=args.check_port)
+
     with sys.stdout if args.outfile == "STDOUT" else open(args.outfile, "w") as fout:
+        LOGGER.info(f"Writing signed certificate to {args.outfile}")
         fout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -189,11 +189,13 @@ def main(argv=None):
     parser.add_argument("--ca", default=DEFAULT_CA, help="DEPRECATED! USE --directory-url INSTEAD!")
     parser.add_argument("--contact", metavar="CONTACT", default=None, nargs="*", help="Contact details (e.g. mailto:aaa@bbb.com) for your account-key")
     parser.add_argument("--check-port", metavar="PORT", default=None, help="what port to use when self-checking the challenge file, default is port 80")
+    parser.add_argument("--outfile", metavar="FILE", required=False, default="STDOUT", help="write signed cert to this file. default=STDOUT")
 
     args = parser.parse_args(argv)
     LOGGER.setLevel(args.quiet or LOGGER.level)
     signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, check_port=args.check_port)
-    sys.stdout.write(signed_crt)
+    with sys.stdout if args.outfile == "STDOUT" else open(args.outfile, "w") as fout:
+        fout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover
     main(sys.argv[1:])

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -196,7 +196,8 @@ def main(argv=None):
     signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, check_port=args.check_port)
 
     with sys.stdout if args.outfile == "STDOUT" else open(args.outfile, "w") as fout:
-        LOGGER.info(f"Writing signed certificate to {args.outfile}")
+        LOGGER.info("Writing signed certificate to {outfile}".format(outfile=args.outfile))
+            )
         fout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -189,15 +189,18 @@ def main(argv=None):
     parser.add_argument("--ca", default=DEFAULT_CA, help="DEPRECATED! USE --directory-url INSTEAD!")
     parser.add_argument("--contact", metavar="CONTACT", default=None, nargs="*", help="Contact details (e.g. mailto:aaa@bbb.com) for your account-key")
     parser.add_argument("--check-port", metavar="PORT", default=None, help="what port to use when self-checking the challenge file, default is port 80")
-    parser.add_argument("--outfile", metavar="FILE", required=False, default="STDOUT", help="write signed cert to this file. default=STDOUT")
+    parser.add_argument("--outfile", metavar="FILE", required=False, default=None, help="write signed cert to this file. default=STDOUT")
 
     args = parser.parse_args(argv)
     LOGGER.setLevel(args.quiet or LOGGER.level)
     signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, check_port=args.check_port)
 
-    with sys.stdout if args.outfile == "STDOUT" else open(args.outfile, "w") as fout:
+    if args.outfile:
         LOGGER.info("Writing signed certificate to {outfile}".format(outfile=args.outfile))
-        fout.write(signed_crt)
+        with open(args.outfile, "w") as fout:
+            fout.write(signed_crt)
+    else:
+        sys.stdout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover
     main(sys.argv[1:])

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -197,7 +197,6 @@ def main(argv=None):
 
     with sys.stdout if args.outfile == "STDOUT" else open(args.outfile, "w") as fout:
         LOGGER.info("Writing signed certificate to {outfile}".format(outfile=args.outfile))
-            )
         fout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover


### PR DESCRIPTION
I have acme-tiny integrated as a systemd service + a timer. I find it handy to also specify an outfile, where the signed certificate + chain should be written to.

Of course, the default behaviour remains, which prints the signed cert to STDOUT.


Output with `--outfile /etc/pki/acme/domainA.cert`:
```
acme_tiny.py[55382]: Certificate signed!
acme_tiny.py[55382]: Writing signed certificate to /etc/pki/acme/domainA.cert
systemd[1]: acme.service: Succeeded.
```

Output without `--outfile`:
```
acme_tiny.py[55468]: Signing certificate...
acme_tiny.py[55468]: Certificate signed!
acme_tiny.py[55468]: Writing signed certificate to STDOUT
acme_tiny.py[55468]: -----BEGIN CERTIFICATE-----
acme_tiny.py[55468]: MIIHPTCCBiWgAwIBAgITAPpExoEu268QebqRtct2tMvL2jANBgkqhkiG9w0BAQsF
...
acme_tiny.py[55468]: oZ2lS38fL18Aon458fbc0BPHtenfhKj5
acme_tiny.py[55468]: -----END CERTIFICATE-----
systemd[1]: acme.service: Succeeded.
```