### PR TITLE
added a timeout to urlopen

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -31,7 +31,7 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
     # helper function - make request and automatically parse json response
     def _do_request(url, data=None, err_msg="Error", depth=0):
         try:
-            resp = urlopen(Request(url, data=data, headers={"Content-Type": "application/jose+json", "User-Agent": "acme-tiny"}))
+            resp = urlopen(Request(url, data=data, headers={"Content-Type": "application/jose+json", "User-Agent": "acme-tiny"}), timeout=5)
             resp_data, code, headers = resp.read().decode("utf8"), resp.getcode(), resp.headers
         except IOError as e:
             resp_data = e.read().decode("utf8") if hasattr(e, "read") else str(e)


### PR DESCRIPTION
I just noticed there was no timeout to `urlopen(`; by default the timeout in `socket` of `None` (no timeout) will be used – which will cause `acme-tiny` to indefinitely hang on a connection issue.

This has caused issues for me with similar code in dev/ci testing; though I have never experienced it in production.

