### PR TITLE
Remove the Python 2 compatibility code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ wget -O - "https://gist.githubusercontent.com/JonLundy/f25c99ee0770e19dc595/raw/
 cp /etc/letsencrypt/accounts/acme-v01.api.letsencrypt.org/directory/<id>/private_key.json private_key.json
 
 # Create a DER encoded private key
-openssl asn1parse -noout -out private_key.der -genconf <(python2 conv.py private_key.json)
+openssl asn1parse -noout -out private_key.der -genconf <(python3 conv.py private_key.json)
 
 # Convert to PEM
 openssl rsa -in private_key.der -inform der > account.key

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 # Copyright Daniel Roesler, under MIT license, see LICENSE at github.com/diafygi/acme-tiny
 import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
-try:
-    from urllib.request import urlopen, Request # Python 3
-except ImportError: # pragma: no cover
-    from urllib2 import urlopen, Request # Python 2
+from urllib.request import urlopen, Request
 
 DEFAULT_CA = "https://acme-v02.api.letsencrypt.org" # DEPRECATED! USE DEFAULT_DIRECTORY_URL INSTEAD
 DEFAULT_DIRECTORY_URL = "https://acme-v02.api.letsencrypt.org/directory"


### PR DESCRIPTION
The shebang line said `python3` since 2020, simplify the code by removing Python 2 support.