### PR TITLE
Add support for --challenge-deploy as an alternative to --acme-dir, also supports DNS-01 challenge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ The rough equivalent of the
 behaviour can thus be achieved with
 ```
    --challenge-deploy 'read d t ka ; echo "$ka" > /var/www/acme-challenges/"$t"'
+   --challenge-cleanup 'read d t ka ; rm -f /var/www/acme-challenges/"$t"'
 ```
+There is also a `--challenge-cleanup` counterpart, run with the same input
+after the authorization passed and the challenge material is no longer needed.
+
 But you probably want to use this version of the script for cases like
 ```
    --challenge-deploy /usr/local/bin/acme-challenge-deploy
@@ -33,6 +37,7 @@ But you probably want to use this version of the script for cases like
 or
 ```
    --challenge-deploy 'ssh -i ~/.ssh/acme-deploy acme@web.example.com 2>&1'
+   --challenge-cleanup 'ssh -i ~/.ssh/acme-deploy acme@web.example.com cleanup 2>&1'
 ```
 
 **PLEASE READ THE SOURCE CODE! YOU MUST TRUST IT WITH YOUR PRIVATE ACCOUNT KEY!**

--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ But you probably want to use this version of the script for cases like
 ```
 or
 ```
+   --challenge-type dns-01
    --challenge-deploy 'ssh -i ~/.ssh/acme-deploy acme@web.example.com 2>&1'
    --challenge-cleanup 'ssh -i ~/.ssh/acme-deploy acme@web.example.com cleanup 2>&1'
 ```
+
+The script also supports option `--challenge-type`, defaulting to `http-01`
+and supporting `dns-01`, which formats the key authorization string passed
+to the deploy and cleanup scripts in a way expected in the DNS TXT record.
 
 **PLEASE READ THE SOURCE CODE! YOU MUST TRUST IT WITH YOUR PRIVATE ACCOUNT KEY!**
 

--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.INFO)
 
-def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check=False, directory_url=DEFAULT_DIRECTORY_URL, contact=None, check_port=None):
+def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check=False, directory_url=DEFAULT_DIRECTORY_URL, contact=None, check_port=None, challenge_deploy=None):
     directory, acct_headers, alg, jwk = None, None, None, None # global variables
 
     # helper functions - base64 encode for jose spec
@@ -21,8 +21,8 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
         return base64.urlsafe_b64encode(b).decode('utf8').replace("=", "")
 
     # helper function - run external commands
-    def _cmd(cmd_list, stdin=None, cmd_input=None, err_msg="Command Line Error"):
-        proc = subprocess.Popen(cmd_list, stdin=stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    def _cmd(cmd_list, stdin=None, cmd_input=None, err_msg="Command Line Error", shell=False):
+        proc = subprocess.Popen(cmd_list, stdin=stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
         out, err = proc.communicate(cmd_input)
         if proc.returncode != 0:
             raise IOError("{0}\n{1}".format(err_msg, err))
@@ -131,27 +131,33 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
             continue
         log.info("Verifying {0}...".format(domain))
 
-        # find the http-01 challenge and write the challenge file
+        # find the http-01 challenge
         challenge = [c for c in authorization['challenges'] if c['type'] == "http-01"][0]
         token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge['token'])
         keyauthorization = "{0}.{1}".format(token, thumbprint)
-        wellknown_path = os.path.join(acme_dir, token)
-        with open(wellknown_path, "w") as wellknown_file:
-            wellknown_file.write(keyauthorization)
-
-        # check that the file is in place
-        try:
-            wellknown_url = "http://{0}{1}/.well-known/acme-challenge/{2}".format(domain, "" if check_port is None else ":{0}".format(check_port), token)
-            assert (disable_check or _do_request(wellknown_url)[0] == keyauthorization)
-        except (AssertionError, ValueError) as e:
-            raise ValueError("Wrote file to {0}, but couldn't download {1}: {2}".format(wellknown_path, wellknown_url, e))
+        wellknown_path = os.path.join(acme_dir, token) if acme_dir else None
+        if wellknown_path:
+            with open(wellknown_path, "w") as wellknown_file:
+                wellknown_file.write(keyauthorization)
+            # check that the file is in place
+            try:
+                wellknown_url = "http://{0}{1}/.well-known/acme-challenge/{2}".format(domain, "" if check_port is None else ":{0}".format(check_port), token)
+                assert (disable_check or _do_request(wellknown_url)[0] == keyauthorization)
+            except (AssertionError, ValueError) as e:
+                raise ValueError("Wrote file to {0}, but couldn't download {1}: {2}".format(wellknown_path, wellknown_url, e))
+        if challenge_deploy:
+            log.info("Running {0}...".format(challenge_deploy))
+            out = _cmd(challenge_deploy, stdin=subprocess.PIPE, cmd_input="{0} {1} {2}\n".format(domain, token, keyauthorization).encode('utf8'),
+                shell=True, err_msg="Error storing key authorization for {0}".format(domain))
+            log.info(("Finished with {0}" if out else "Finished.").format(out.decode('utf8')))
 
         # say the challenge is done
         _send_signed_request(challenge['url'], {}, "Error submitting challenges: {0}".format(domain))
         authorization = _poll_until_not(auth_url, ["pending"], "Error checking challenge status for {0}".format(domain))
         if authorization['status'] != "valid":
             raise ValueError("Challenge did not pass for {0}: {1}".format(domain, authorization))
-        os.remove(wellknown_path)
+        if wellknown_path:
+            os.remove(wellknown_path)
         log.info("{0} verified!".format(domain))
 
     # finalize the order with the csr
@@ -182,7 +188,8 @@ def main(argv=None):
     )
     parser.add_argument("--account-key", required=True, help="path to your Let's Encrypt account private key")
     parser.add_argument("--csr", required=True, help="path to your certificate signing request")
-    parser.add_argument("--acme-dir", required=True, help="path to the .well-known/acme-challenge/ directory")
+    parser.add_argument("--acme-dir", help="path to the .well-known/acme-challenge/ directory")
+    parser.add_argument("--challenge-deploy", help="script which gets called to expose the key authorization in webserver")
     parser.add_argument("--quiet", action="store_const", const=logging.ERROR, help="suppress output except for errors")
     parser.add_argument("--disable-check", default=False, action="store_true", help="disable checking if the challenge file is hosted correctly before telling the CA")
     parser.add_argument("--directory-url", default=DEFAULT_DIRECTORY_URL, help="certificate authority directory url, default is Let's Encrypt")
@@ -191,8 +198,10 @@ def main(argv=None):
     parser.add_argument("--check-port", metavar="PORT", default=None, help="what port to use when self-checking the challenge file, default is port 80")
 
     args = parser.parse_args(argv)
+    if not (args.acme_dir or args.challenge_deploy):
+        parser.error('Specify at least --acme-dir or --challenge-deploy')
     LOGGER.setLevel(args.quiet or LOGGER.level)
-    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, check_port=args.check_port)
+    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, check_port=args.check_port, challenge_deploy=args.challenge_deploy)
     sys.stdout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover


### PR DESCRIPTION
I'm offering for consideration changes that make it possible to offload the challenge work to external scripts.

So instead of
```
    --acme-dir /var/www/acme-challenges/
```
you can use
```
    --challenge-deploy 'read d t ka ; echo "$ka" > /var/www/acme-challenges/"$t"'
```

That by itself does not sound useful but it gets useful in situations like
```
    --challenge-deploy /usr/local/bin/acme-challenge-deploy-to-my-servers
```
or
```
    --challenge-deploy 'ssh -i ~/.ssh/acme-deploy acme@web.example.com 2>&1'
```

The change itself is not ready for merging on top of master as the code exceeds the 200 line limit.

However, when applied on top of other pull requests that are currently open, namely https://github.com/diafygi/acme-tiny/pull/296, https://github.com/diafygi/acme-tiny/pull/297, or parts of https://github.com/diafygi/acme-tiny/pull/273 (I can provide separate PR for just the "Remove comments where the subsequent log.info line can carry the same information" part), it is possible to have this logic within 200 lines.

Moving the challenge deployment logic to external script lends itself nicely to the DNS-01 challenge type support, as the only thing that is needed in the acme-tiny code is a support for the slightly different key authorization token format.

I've been running with this change for a couple of weeks and I feel I can show it now.