### PR TITLE
Provide a replacement implementation for dns-persist-01 (see issue #308)

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright Daniel Roesler, under MIT license, see LICENSE at github.com/diafygi/acme-tiny
-import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
+import argparse, subprocess, json, sys, base64, binascii, time, re, textwrap, logging
+from urllib.parse import urlencode # for checking dns before triggering challenge
 try:
     from urllib.request import urlopen, Request # Python 3
 except ImportError: # pragma: no cover
@@ -8,12 +9,12 @@ except ImportError: # pragma: no cover
 
 DEFAULT_CA = "https://acme-v02.api.letsencrypt.org" # DEPRECATED! USE DEFAULT_DIRECTORY_URL INSTEAD
 DEFAULT_DIRECTORY_URL = "https://acme-v02.api.letsencrypt.org/directory"
-
+DEFAULT_DNS_OVER_HTTPS_JSON = "https://dns.google/resolve"  # HTTP 1.1
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.INFO)
 
-def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check=False, directory_url=DEFAULT_DIRECTORY_URL, contact=None, check_port=None):
+def get_crt(account_key, csr, log=LOGGER, CA=DEFAULT_CA, disable_check=False, directory_url=DEFAULT_DIRECTORY_URL, contact=None, policy_wildcard=None, persist_until=None):
     directory, acct_headers, alg, jwk = None, None, None, None # global variables
 
     # helper functions - base64 encode for jose spec
@@ -82,8 +83,6 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
         "kty": "RSA",
         "n": _b64(binascii.unhexlify(re.sub(r"(\s|:)", "", pub_hex).encode("utf-8"))),
     }
-    accountkey_json = json.dumps(jwk, sort_keys=True, separators=(',', ':'))
-    thumbprint = _b64(hashlib.sha256(accountkey_json.encode('utf8')).digest())
 
     # find domains
     log.info("Parsing CSR...")
@@ -131,27 +130,25 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, disable_check
             continue
         log.info("Verifying {0}...".format(domain))
 
-        # find the http-01 challenge and write the challenge file
-        challenge = [c for c in authorization['challenges'] if c['type'] == "http-01"][0]
-        token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge['token'])
-        keyauthorization = "{0}.{1}".format(token, thumbprint)
-        wellknown_path = os.path.join(acme_dir, token)
-        with open(wellknown_path, "w") as wellknown_file:
-            wellknown_file.write(keyauthorization)
-
-        # check that the file is in place
+        # find the dns-persist-01 challenge and display the challenge information
         try:
-            wellknown_url = "http://{0}{1}/.well-known/acme-challenge/{2}".format(domain, "" if check_port is None else ":{0}".format(check_port), token)
-            assert (disable_check or _do_request(wellknown_url)[0] == keyauthorization)
-        except (AssertionError, ValueError) as e:
-            raise ValueError("Wrote file to {0}, but couldn't download {1}: {2}".format(wellknown_path, wellknown_url, e))
+            challenge = [c for c in authorization['challenges'] if c['type'] == "dns-persist-01"][0]
+        except IndexError:
+            raise IndexError("Challenge `dns-persist-01` not supported by this ACME provider")
+        log.info("Please configure DNS TXT data `{1}` for record `{0}` for validation".format(
+            '_validation-persist.' + domain, challenge['issuer-domain-names'][0] + "; " + acct_headers['Location']
+            + ("; policy=wildcard" if policy_wildcard else "") + ("" if persist_until is None else "; persistUntil=" + str(persist_until))))
+
+        # check that the DNS record is in place
+        dns_url = DEFAULT_DNS_OVER_HTTPS_JSON + "?" + urlencode({"name": domain, "type": "TXT"})
+        while not disable_check and 'Answer' not in json.load(urlopen(dns_url)):
+            time.sleep(2)
 
         # say the challenge is done
         _send_signed_request(challenge['url'], {}, "Error submitting challenges: {0}".format(domain))
         authorization = _poll_until_not(auth_url, ["pending"], "Error checking challenge status for {0}".format(domain))
         if authorization['status'] != "valid":
             raise ValueError("Challenge did not pass for {0}: {1}".format(domain, authorization))
-        os.remove(wellknown_path)
         log.info("{0} verified!".format(domain))
 
     # finalize the order with the csr
@@ -177,22 +174,23 @@ def main(argv=None):
             It will need to be run on your server and have access to your private account key, so PLEASE READ THROUGH IT!
             It's only ~200 lines, so it won't take long.
 
-            Example Usage: python acme_tiny.py --account-key ./account.key --csr ./domain.csr --acme-dir /usr/share/nginx/html/.well-known/acme-challenge/ > signed_chain.crt
+            Example Usage: python acme_tiny.py --account-key ./account.key --csr ./domain.csr > signed_chain.crt
+            IMPORTANT: Until dns-persist-01 is available in production, add `--directory-url https://acme-staging-v02.api.letsencrypt.org/directory` to test using staging
             """)
     )
     parser.add_argument("--account-key", required=True, help="path to your Let's Encrypt account private key")
     parser.add_argument("--csr", required=True, help="path to your certificate signing request")
-    parser.add_argument("--acme-dir", required=True, help="path to the .well-known/acme-challenge/ directory")
     parser.add_argument("--quiet", action="store_const", const=logging.ERROR, help="suppress output except for errors")
     parser.add_argument("--disable-check", default=False, action="store_true", help="disable checking if the challenge file is hosted correctly before telling the CA")
     parser.add_argument("--directory-url", default=DEFAULT_DIRECTORY_URL, help="certificate authority directory url, default is Let's Encrypt")
     parser.add_argument("--ca", default=DEFAULT_CA, help="DEPRECATED! USE --directory-url INSTEAD!")
     parser.add_argument("--contact", metavar="CONTACT", default=None, nargs="*", help="Contact details (e.g. mailto:aaa@bbb.com) for your account-key")
-    parser.add_argument("--check-port", metavar="PORT", default=None, help="what port to use when self-checking the challenge file, default is port 80")
+    parser.add_argument("--policy-wildcard", default=False, action="store_true", help="allow wildcard certificates")
+    parser.add_argument("--persist-until", metavar="TIMESTAMP", default=None, help="maximum integer unix timestamp when the challenge can succeed")
 
     args = parser.parse_args(argv)
     LOGGER.setLevel(args.quiet or LOGGER.level)
-    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, check_port=args.check_port)
+    signed_crt = get_crt(args.account_key, args.csr, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact, policy_wildcard=args.policy_wildcard, persist_until=args.persist_until)
     sys.stdout.write(signed_crt)
 
 if __name__ == "__main__": # pragma: no cover


### PR DESCRIPTION
See: https://github.com/diafygi/acme-tiny/issues/308

Implementation choice:
- I do not know if upstream has a desire to implement dns-persist-01
- I could not figure how to get both `http-01` and `dns-persist-01` in,
  so I **replaced** http-01 impl with dns-persist-01 to stay below 200 LOC
- it is up to the upstream to decide if this fits (and how to include it)

Implementation summary:
- adds `policy-wildcard` and `persist-until` dns-persist-01 options
- handles dns-persist-01 challenge *instead* of http-01
- displays the challenge the user must configure in their DNS
- waits for the proof to be present **using DNS-over-HTTPS JSON**
- removes http-01 parts not used by dns-persist-01 challenge

Tests:
- TARGET: only tested using python 3.10 + trixie devcontainer
- PASS: using LetsEncrypt staging and a personnal DNS record
- FAIL (graceful): LetsEncrypt production (as not yet available)
- SKIPPED: using pebble, as i could not understand how to do it

Information : this PR is my second take on dns-persist-01 after [this one](https://github.com/nipil/acme-tiny-dns-persistent.git) which has similar-but-different design goals, like an opinionated two step process with different privilege separation, and a challenge output which is compatible with downstream machine processing for DNS setup.