### PR TITLE
Remove unused imports and variables (F401, F841)

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright Daniel Roesler, under MIT license, see LICENSE at github.com/diafygi/acme-tiny
-import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, copy, textwrap, logging
+import argparse, subprocess, json, os, sys, base64, binascii, time, hashlib, re, textwrap, logging
 try:
     from urllib.request import urlopen, Request # Python 3
 except ImportError: # pragma: no cover

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-from .test_module import TestModule
-from .test_install import TestInstall
+from .test_module import TestModule as TestModule
+from .test_install import TestInstall as TestInstall

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,11 +1,9 @@
 import os
 import sys
 import json
-import time
 import shutil
 import logging
 import unittest
-import tempfile
 from subprocess import Popen, PIPE
 
 try:
@@ -91,7 +89,7 @@ class TestModule(unittest.TestCase):
         """ Successfully issue a certificate via subject alt name """
         old_stdout = sys.stdout
         sys.stdout = StringIO()
-        result = acme_tiny.main([
+        acme_tiny.main([
             "--account-key", self.KEYS['account_key'].name,
             "--csr", self.KEYS['domain_csr'].name,
             "--acme-dir", self.tempdir,
@@ -117,7 +115,7 @@ class TestModule(unittest.TestCase):
         # issue the cert again, where challenges should already be valid
         old_stdout = sys.stdout
         sys.stdout = StringIO()
-        result = acme_tiny.main([
+        acme_tiny.main([
             "--account-key", self.KEYS['account_key'].name,
             "--csr", self.KEYS['domain_csr'].name,
             "--acme-dir", self.tempdir,
@@ -125,7 +123,7 @@ class TestModule(unittest.TestCase):
             "--check-port", self.check_port,
         ])
         sys.stdout.seek(0)
-        crt = sys.stdout.read().encode("utf8")
+        sys.stdout.read().encode("utf8")
         sys.stdout = old_stdout
         log_output.seek(0)
         log_string = log_output.read().encode("utf8")
@@ -234,7 +232,7 @@ class TestModule(unittest.TestCase):
         # call acme_tiny with new contact details
         old_stdout = sys.stdout
         sys.stdout = StringIO()
-        result = acme_tiny.main([
+        acme_tiny.main([
             "--account-key", self.KEYS['account_key'].name,
             "--csr", self.KEYS['domain_csr'].name,
             "--acme-dir", self.tempdir,
@@ -431,7 +429,7 @@ class TestModule(unittest.TestCase):
         """ Successfully issue a certificate via common name """
         old_stdout = sys.stdout
         sys.stdout = StringIO()
-        result = acme_tiny.main([
+        acme_tiny.main([
             "--account-key", self.KEYS['account_key'].name,
             "--csr", self.KEYS['cn_csr'].name,
             "--acme-dir", self.tempdir,


### PR DESCRIPTION
Remove unused imports across the codebase and unused local variables in tests flagged by Ruff rules F401 and F841.